### PR TITLE
Support DocsMath

### DIFF
--- a/src/components/docsMathDecorator.js
+++ b/src/components/docsMathDecorator.js
@@ -1,0 +1,28 @@
+// @flow
+import React from "react";
+
+type DocsMathDecoratorEntityData = {|
+  asciimath?: ?string,
+  latex?: ?string,
+  text?: ?string,
+  xml?: ?string
+|};
+
+export default class DocsMathDecorator extends React.Component {
+  render() {
+    const { contentState, entityKey } = this.props;
+    const data: DocsMathDecoratorEntityData = contentState
+      .getEntity(entityKey)
+      .getData();
+    return (
+      <math
+        data-asciimath={data.asciimath}
+        data-latex={data.latex}
+        data-text={data.text}
+        data-xml={data.xml}
+      >
+        {data.latex}
+      </math>
+    );
+  }
+}

--- a/src/editor_configuration/DocsConfig.js
+++ b/src/editor_configuration/DocsConfig.js
@@ -3,6 +3,8 @@
 import DocsDecorator from "./DocsDecorator.js";
 import DocsImageDecorator from "../components/docsImageDecorator.js";
 import DocsLinkDecorator from "../components/docsLinkDecorator.js";
+import DocsMathDecorator from "../components/docsMathDecorator.js";
+
 import DocsDecoratorTypes from "./DocsDecoratorTypes";
 
 function registerDecorator(specs: Array<Array<any>>): void {
@@ -16,6 +18,7 @@ function init(): void {
   // Register Decorator
   registerDecorator([[DocsDecoratorTypes.DOCS_IMAGE, DocsImageDecorator]]);
   registerDecorator([[DocsDecoratorTypes.LINK, DocsLinkDecorator]]);
+  registerDecorator([[DocsDecoratorTypes.DOCS_MATH, DocsMathDecorator]]);
 }
 
 module.exports = {


### PR DESCRIPTION
Stacking this on top of https://github.com/chanzuckerberg/slim-editor/pull/2

This adds link support

## Test Plan

given 

```json
{
  "blocks": [
    {
      "key": "c54at",
      "text": " ​ ",
      "type": "unstyled",
      "depth": 0,
      "inlineStyleRanges": [],
      "entityRanges": [
        {
          "offset": 1,
          "length": 1,
          "key": 0
        }
      ],
      "data": {}
    }
  ],
  "entityMap": {
    "0": {
      "type": "DOCS_MATH",
      "mutability": "IMMUTABLE",
      "data": {
        "xml": "<m v=\"1.2.0\"><e></e><f group=\"greek\" type=\"delta\"><b p=\"latex\">\\delta</b><b p=\"asciimath\"> delta </b></f><e current=\"yes\" caret=\"1\">5</e></m>",
        "text": "(delta * 5)",
        "latex": " \\delta  5 "
      }
    }
  }
}
```

Outputs:

```html
<div data-contents="true"><div class="" data-block="true" data-editor="4gq1s" data-offset-key="c54at-0-0"><div data-offset-key="c54at-0-0" class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"><span data-offset-key="c54at-0-0"><span data-text="true"> </span></span><math data-latex=" \delta  5 " data-text="(delta * 5)" data-xml="<m v=&quot;1.2.0&quot;><e></e><f group=&quot;greek&quot; type=&quot;delta&quot;><b p=&quot;latex&quot;>\delta</b><b p=&quot;asciimath&quot;> delta </b></f><e current=&quot;yes&quot; caret=&quot;1&quot;>5</e></m>"></math><span data-offset-key="c54at-2-0"><span data-text="true"> </span></span></div></div></div>
```

@hedgerwang , can you help me understand if this is escaped the way you want? I have a feeling it's not but am strugling to understand what the escaped output would look like.

Data-xml currently starts with  `data-xml="<m v=&quot;1.2.0&quot;>`, should it be `data-xml="<m v=\"1.2.0\">` instead?